### PR TITLE
fix build

### DIFF
--- a/src/backend/Cargo.toml
+++ b/src/backend/Cargo.toml
@@ -20,4 +20,4 @@ validator_derive = "0.20.0"
 anyhow = "1.0.99"
 
 [build-dependencies]
-ic-sql-migrate = { version = "0.0.4", features = ["sqlite"] }
+ic-sql-migrate = { version = "0.0.4"}


### PR DESCRIPTION
The project doesn't seem to compile out of the box. 
**The reason:** build dependencies are always targeting host architecture in rust, as a result the `ic-rusqlite` is not able to compile as it only works for WASI at the moment.

**Solution:** remove feature `sqlite` from the `ic-sql-migrate` build dependency.